### PR TITLE
Use `Math.pow` instead of `**` in the Spaced Repetition Settings JS

### DIFF
--- a/apps/koohii/modules/account/templates/spacedrepetitionSuccess.php
+++ b/apps/koohii/modules/account/templates/spacedrepetitionSuccess.php
@@ -128,7 +128,7 @@ App.ready(function(){
       nthInterval(n) {
         let first  = 3;
         let mult   = 1.0 * Number(this.srs_mult / 100).toFixed(2); // 205 => 2.05
-        return  Math.ceil( first * (mult ** (n - 1)) );
+        return  Math.ceil( first * Math.pow(mult, n - 1) );
       }
 
     },


### PR DESCRIPTION
Unfortunately some browsers don't support ES2016 yet. Consequently, the new Spaced Repetition Settings page fails to load.
Hopefully this trivial patch will be enough to fix that (I haven't seen `**` used anywhere else and the only other new ES2016 feature is `Array.prototype.includes`, and I haven't found any instances of that either).